### PR TITLE
Add the ability to pass a context to the REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ const repl = sshrepl({
       repl: { prompt: 'bar> ' }
     }
   },
-  port: 2244
+  port: 2244,
+  context: {
+      foo: 'bar'
+  }
 }, function(err, boundPort) {
   if (err) throw err;
   console.log('SSH REPL listening');
@@ -66,5 +69,7 @@ API
             * **publicKey** - _mixed_ - The public key for the user. This value can be a _Buffer_ instance or a _string_.
 
         * **repl** - _object_ - If supplied, the properties on this object are passed on to [`repl.start()`](https://nodejs.org/docs/latest/api/repl.html#repl_repl_start_options).
+
+    * **context** - _object_ - The context object to pass to the REPL. **Default:** (none)
 
     If `callback` is supplied, it is called once the SSH REPL is listening for incoming connections. It has the signature (< _Error_ >err, < _number_ >boundPort). The `boundPort` argument is useful when binding on port 0.

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,8 @@ module.exports = function createServer(cfg, cb) {
     throw new Error('Missing/Invalid port');
   if (typeof cfg.users !== 'object' && typeof cfg.users !== 'function')
     throw new Error('Missing/Invalid users configuration');
+  if ('context' in cfg && typeof cfg.context !== 'object')
+    throw new Error('Invalid context');
 
   const users_ = cfg.users;
   var users;
@@ -121,7 +123,12 @@ module.exports = function createServer(cfg, cb) {
             }
           }
 
-          repl.start(options).once('exit', function () {
+          const replServer = repl.start(options);
+
+          if ('context' in cfg)
+            Object.assign(replServer.context, cfg.context);
+
+          replServer.once('exit', function () {
             stream.close();
           });
           stream.once('close', function() {


### PR DESCRIPTION
I just added a few lines so that the user can pass a `context` object in the options.
This context is then copied to the REPL's context using `Object.assign`.
I updated the README consequently.
:)